### PR TITLE
add library file names for darwin/macos

### DIFF
--- a/qahirah.py
+++ b/qahirah.py
@@ -59,6 +59,12 @@ LIBNAME = \
                 "freetype" : "libfreetype.so.28",
                 "fontconfig" : "libfontconfig.so.11",
             },
+        "darwin" :
+            {
+                "cairo" : "libcairo.2.dylib",
+                "freetype" : "libfreetype.6.dylib",
+                "fontconfig" : "libfontconfig.1.dylib",
+            },
     }[sys.platform]
 
 cairo = ct.cdll.LoadLibrary(LIBNAME["cairo"])


### PR DESCRIPTION
Tested with latest cairo, freetype and fontconfig from homebrew. 

All of the examples from https://gitlab.com/ldo/qahirah_examples work, except for bulk_fonts because bulk_fonts imports 'freetype2', and it's not clear to me what python module this import is intended to resolve to.